### PR TITLE
fix deprecated express API method and update package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,15 @@ var supportedMimes = [
 ];
 
 var _tempCache = [];
+
+var send = function (res, path, callback){
+	var sendMethod = typeof res.sendFile === "undefined" ? res.sendfile : res.sendFile;
+	
+	sendMethod.call(res, path, callback);
+}
+
 var sendAndSave = function (res, path) {
-	res.sendfile(path);
+	send(res, path);
 	_tempCache.push(path);
 };
 
@@ -55,7 +62,7 @@ module.exports = function(basePath, options) {
 
 			// try lookup cache for fast access
 			if(_tempCache.indexOf(cachePath) !== -1) {
-				res.sendfile(cachePath, function(err) {
+				send(res, cachePath, function(err) {
 					if(err) {
 						_tempCache.splice(_tempCache.indexOf(cachePath), 1);
 						webpMiddleware(req, res, next);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webp-middleware",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Generates and delivers JPG-, PNG- and TIFF-images on the fly as WebP-images if the client supports that format",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "mkdirp": "~0.3.5"
   },
   "devDependencies": {
-    "express": "~3.4.0"
+    "express": "~4.13.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi Jannick, I was getting the following deprecation warnings when using this module with Express 4:

![deprecated](https://cloud.githubusercontent.com/assets/1478717/14117489/e61e2ca8-f5b2-11e5-98a8-ee92a945b718.png)

So I created a method `send` in index.js that wraps res.sendFile such that the module supports both Express 4 and earlier versions of the framework. Please let me know if I need to make additional changes before this can be merged in.
