### PR TITLE
fixed broken request header options fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = function(basePath, options) {
     var accept = req.headers.accept;
 
     var hasMimetype = supportedMimes.indexOf(mimeType) !== -1;
-    var acceptWebp = Array.isArray(accept) && accept.indexOf('image/webp') !== -1;
+    var acceptWebp = accept && accept.indexOf('image/webp') !== -1;
 
     // just move on if mimetypes does not match
     if (!hasMimetype || !acceptWebp) {


### PR DESCRIPTION
This fixes the fix f296de7c4b1eec54b06fbef412d5ec990508e1ba where it is checked if the request header options exists.

The above fix was implemented poorly as it assumed the header was an array when it is actually a string. Because of this nothing was served as `webp`.. ;-)
